### PR TITLE
DIT-2083 Fix problems with file size limit and mongo JSON size limit when uploading migrations

### DIFF
--- a/app/uk/gov/hmrc/bindingtariffadminfrontend/lock/MigrationLock.scala
+++ b/app/uk/gov/hmrc/bindingtariffadminfrontend/lock/MigrationLock.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.bindingtariffadminfrontend.lock
+
+import javax.inject.{Inject, Singleton}
+import uk.gov.hmrc.lock.LockKeeper
+import uk.gov.hmrc.lock.LockRepository
+import org.joda.time.Duration
+import uk.gov.hmrc.bindingtariffadminfrontend.config.AppConfig
+
+@Singleton
+class MigrationLock @Inject() (lockRepository: LockRepository, appConfig: AppConfig) extends LockKeeper {
+  val lockName = "DataMigration"
+  val repo = lockRepository
+  val lockId = s"$lockName-scheduled-job-lock"
+  val forceLockReleaseAfter: Duration = Duration.millis(appConfig.dataMigrationLockLifetime.toMillis)
+}

--- a/app/uk/gov/hmrc/bindingtariffadminfrontend/scheduler/MigrationJob.scala
+++ b/app/uk/gov/hmrc/bindingtariffadminfrontend/scheduler/MigrationJob.scala
@@ -55,6 +55,7 @@ class MigrationJob @Inject()(appConfig: AppConfig,
   }
 
   private def process(count: Int = 0)(implicit ctx: ExecutionContext): Future[Int] = {
+    // TODO: Request migrations in batches rather than one at a time to improve performance
     service.getNextMigration flatMap {
       case Some(migration) if count < 100 =>
         process(migration).flatMap { result =>

--- a/app/uk/gov/hmrc/bindingtariffadminfrontend/scheduler/MigrationJob.scala
+++ b/app/uk/gov/hmrc/bindingtariffadminfrontend/scheduler/MigrationJob.scala
@@ -22,6 +22,7 @@ import javax.inject.Inject
 import org.joda.time.Duration
 import play.api.Logger
 import uk.gov.hmrc.bindingtariffadminfrontend.config.AppConfig
+import uk.gov.hmrc.bindingtariffadminfrontend.lock.MigrationLock
 import uk.gov.hmrc.bindingtariffadminfrontend.model.{Migration, MigrationStatus}
 import uk.gov.hmrc.bindingtariffadminfrontend.service.DataMigrationService
 import uk.gov.hmrc.http.HeaderCarrier
@@ -33,11 +34,14 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class MigrationJob @Inject()(appConfig: AppConfig,
                              service: DataMigrationService,
+                             migrationLock: MigrationLock,
                              override val lockRepository: LockRepository) extends LockedScheduledJob {
 
   private implicit val headers: HeaderCarrier = HeaderCarrier()
 
   override def name: String = "DataMigration"
+
+  override lazy val lockKeeper: MigrationLock = migrationLock
 
   override val releaseLockAfter: Duration = Duration.millis(appConfig.dataMigrationLockLifetime.toMillis)
 

--- a/app/uk/gov/hmrc/bindingtariffadminfrontend/service/DataMigrationService.scala
+++ b/app/uk/gov/hmrc/bindingtariffadminfrontend/service/DataMigrationService.scala
@@ -73,7 +73,10 @@ class DataMigrationService @Inject()(repository: MigrationRepository,
       val innerInsert = repository.insert(group)
       Await.result(innerInsert, 30.seconds)
 
-      if (priority) Future.sequence(group.map(process(_).flatMap(update)))
+      if (priority) {
+        val future = Future.sequence(group.map(process(_).flatMap(update)))
+        Await.result(future, 30.seconds)
+      }
     }
 
     Future.successful(true)

--- a/app/uk/gov/hmrc/bindingtariffadminfrontend/service/DataMigrationService.scala
+++ b/app/uk/gov/hmrc/bindingtariffadminfrontend/service/DataMigrationService.scala
@@ -76,12 +76,12 @@ class DataMigrationService @Inject()(repository: MigrationRepository,
     repository.countByStatus
   }
 
-  def prepareMigrationGroup(cases: Seq[Migration], priority: Boolean)(implicit hc: HeaderCarrier): Future[Boolean] = {
+  def prepareMigrationGroup(migrations: Seq[Migration], priority: Boolean)(implicit hc: HeaderCarrier): Future[Boolean] = {
     for {
-      _ <- repository.delete(cases)
-      result <- repository.insert(cases)
+      _ <- repository.delete(migrations)
+      result <- repository.insert(migrations)
       _ <- if (priority) {
-        Future.sequence(cases.map(process(_).flatMap(update)))
+        Future.sequence(migrations.map(process(_).flatMap(update)))
       } else Future.successful(())
     } yield result
   }

--- a/app/uk/gov/hmrc/bindingtariffadminfrontend/service/DataMigrationService.scala
+++ b/app/uk/gov/hmrc/bindingtariffadminfrontend/service/DataMigrationService.scala
@@ -107,7 +107,7 @@ class DataMigrationService @Inject()(repository: MigrationRepository,
       .grouped(groupSize)
       .toList
 
-    withMigrationLock(attemptNumber = 0, baseDelay = 2.seconds, delayCap = 60.seconds) {
+    withMigrationLock(attemptNumber = 0, baseDelay = 1.second, delayCap = 60.seconds) {
       (true, migrationGroups).tailRecM {
         // Processed all groups
         case (result, Nil) =>

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val microservice = (project in file("."))
   .settings(PlayKeys.playDefaultPort := 9584)
   .settings(
     name := appName,
-    scalaVersion := "2.11.11",
+    scalaVersion := "2.11.12",
     targetJvm := "jvm-1.8",
     libraryDependencies ++= (AppDependencies.compile ++ AppDependencies.test).map(_ withSources()),
     evictionWarningOptions in update := EvictionWarningOptions.default.withWarnScalaVersionEviction(false),

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -128,7 +128,7 @@ mongodb {
 
 scheduler {
   data-migration {
-    lock-lifetime = 60s
+    lock-lifetime = 1h
     interval = 15s
   }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -128,7 +128,7 @@ mongodb {
 
 scheduler {
   data-migration {
-    lock-lifetime = 1h
+    lock-lifetime = 60s
     interval = 15s
   }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -135,8 +135,8 @@ scheduler {
 
 tariff-classification-frontend = "http://localhost:9581"
 
-play.http.parser.maxMemoryBuffer=100MB
-play.http.parser.maxDiskBuffer=100MB
+play.http.parser.maxMemoryBuffer=1000MB
+play.http.parser.maxDiskBuffer=1000MB
 
 play.ws.timeout.request = 360000    # 360 secs
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -18,7 +18,9 @@ object AppDependencies {
     "org.reactivemongo"           %% "reactivemongo-akkastream"   % "0.20.1",
     "com.lightbend.akka"          %% "akka-stream-alpakka-csv"    % "1.1.2",
     "com.typesafe.akka"           %% "akka-http"                  % "10.0.12",
-    "com.typesafe.akka"           %% "akka-stream"                % "2.5.8"
+    "com.typesafe.akka"           %% "akka-stream"                % "2.5.8",
+    "org.typelevel"               %% "cats-core"                  % "2.0.0",
+    "org.typelevel"               %% "alleycats-core"             % "2.0.0"
   )
 
   private lazy val scope = "test, it"


### PR DESCRIPTION
* Increase Play memory and disk buffer to allow larger file uploads
* Batch migration inserts and deletes to Mongo to ensure large payloads can be handled successfully
* Ensure that file uploads and the background scheduled task use the same mongo lock so that they don't trample all over each other
* Reduce the lock lifetime for the file upload and the scheduled migration job from 1 hour to 1 minute as we don't expect a single upload or a single batch of migrations to take such a long time and this prevents other tasks from making progress.