### PR TITLE
DIT-2083 Implement ZIP decompression for uploaded case migration data

### DIFF
--- a/app/uk/gov/hmrc/bindingtariffadminfrontend/controllers/DataMigrationJsonController.scala
+++ b/app/uk/gov/hmrc/bindingtariffadminfrontend/controllers/DataMigrationJsonController.scala
@@ -169,8 +169,8 @@ class DataMigrationJsonController @Inject()(authenticatedAction: AuthenticatedAc
     }
     .map{ dataContent =>
       Ok.chunked(dataContent).withHeaders(
-        "Content-Type" -> "application/json",
-        "Content-Disposition" -> s"attachment; filename=$jsonType-Data-Migration${DateTime.now().toString("ddMMyyyyHHmmss")}.json")
+        "Content-Type" -> "application/zip",
+        "Content-Disposition" -> s"attachment; filename=$jsonType-Data-Migration${DateTime.now().toString("ddMMyyyyHHmmss")}.zip")
     }
   }
 

--- a/app/uk/gov/hmrc/bindingtariffadminfrontend/views/case_migration_upload.scala.html
+++ b/app/uk/gov/hmrc/bindingtariffadminfrontend/views/case_migration_upload.scala.html
@@ -34,7 +34,7 @@
   @input_file(
    field = form("file"),
    label = "Upload a JSON File",
-   accept = Some(".json")
+   accept = Some(".json,.zip")
   )
 
   @if(request.operator == "test") {


### PR DESCRIPTION
This PR implements the changes required to match https://github.com/hmrc/binding-tariff-data-transformation/pull/28 - uploaded ZIP files are decompressed before being read as JSON. This code assumes that the uploaded zip file contains only one entry and that its content type can be recognised as `application/zip`.