### PR TITLE
DIT-2172 Make the referral event model consistent with the backend

### DIFF
--- a/app/uk/gov/hmrc/bindingtariffadminfrontend/model/classification/Event.scala
+++ b/app/uk/gov/hmrc/bindingtariffadminfrontend/model/classification/Event.scala
@@ -80,11 +80,11 @@ object CaseStatusChange {
 case class ReferralCaseStatusChange
 (
   override val from: CaseStatus,
-  override val to: CaseStatus,
   override val comment: Option[String] = None,
   referredTo: String,
   reason: Seq[ReferralReason]
 ) extends FieldChange[CaseStatus] {
+  override val to: CaseStatus = CaseStatus.REFERRED
   override val `type`: EventType.Value = EventType.CASE_REFERRAL
 }
 


### PR DESCRIPTION
At the moment the expectation that the `to` field will be in the JSON causes deserialisation failures for referral events.

Since it doesn't make sense for this field to have any other value than `REFERRED` I have made this model match the backend rather than the other way around.