### PR TITLE
Make sure to stream JSON result files

### DIFF
--- a/app/uk/gov/hmrc/bindingtariffadminfrontend/controllers/DataMigrationJsonController.scala
+++ b/app/uk/gov/hmrc/bindingtariffadminfrontend/controllers/DataMigrationJsonController.scala
@@ -169,14 +169,13 @@ class DataMigrationJsonController @Inject()(
   }
 
   private def downloadJson(download : Future[WSResponse], jsonType : String): Future[Result] ={
-    download.map{ res =>
-      res.status match{
-        case OK => res.body
+    download.map { res =>
+      res.status match {
+        case OK => res.bodyAsSource
         case _ => throw new BadRequestException(s"Failed to get mapped json from data migration api for $jsonType" + res.status)
       }
-    }
-    .map{ dataContent =>
-      Ok.chunked[String](Source(List(dataContent))).withHeaders(
+    }.map{ dataContent =>
+      Ok.chunked(dataContent).withHeaders(
         "Content-Type" -> "application/zip",
         "Content-Disposition" -> s"attachment; filename=$jsonType-Data-Migration${DateTime.now().toString("ddMMyyyyHHmmss")}.zip")
     }

--- a/test/unit/uk/gov/hmrc/bindingtariffadminfrontend/controllers/DataMigrationJsonControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffadminfrontend/controllers/DataMigrationJsonControllerSpec.scala
@@ -44,6 +44,8 @@ import uk.gov.hmrc.http._
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration._
 import scala.concurrent.Future
+import akka.util.ByteString
+import org.mockito.Mockito
 
 class DataMigrationJsonControllerSpec extends ControllerSpec with BeforeAndAfterEach {
 
@@ -299,9 +301,11 @@ class DataMigrationJsonControllerSpec extends ControllerSpec with BeforeAndAfter
                               |  }
                               |}""".stripMargin)
 
+      val jsonData = Source.single(ByteString.fromString(json.toString()))
+
       val response: WSResponse = mock[WSResponse]
       when(response.status).thenReturn(200)
-      when(response.body).thenReturn(json.toString())
+      when(response.bodyAsSource: Source[ByteString, Any]).thenReturn(jsonData)
 
       given(migrationConnector.downloadBTIJson).willReturn(Future.successful(response))
 
@@ -341,9 +345,11 @@ class DataMigrationJsonControllerSpec extends ControllerSpec with BeforeAndAfter
                               |  }
                               |}""".stripMargin)
 
+      val jsonData = Source.single(ByteString.fromString(json.toString()))
+
       val response: WSResponse = mock[WSResponse]
       when(response.status).thenReturn(200)
-      when(response.body).thenReturn(json.toString())
+      when(response.bodyAsSource: Source[ByteString, Any]).thenReturn(jsonData)
       given(migrationConnector.downloadLiabilitiesJson).willReturn(Future.successful(response))
 
       val result = await(controller.downloadLiabilitiesJson()(newFakeRequestWithCSRF))


### PR DESCRIPTION
The implementation of `downloadJson` uses `body` to pass through the response from the backend, which is not recommended. Changes this to use `bodyAsSource` instead so that we don't get `akka.stream.StreamLimitReachedException: limit of 13 reached` when downloading large files.