### PR TITLE
DIT-2185 | Added missing AppealType enum value

### DIFF
--- a/app/uk/gov/hmrc/bindingtariffadminfrontend/model/classification/AppealType.scala
+++ b/app/uk/gov/hmrc/bindingtariffadminfrontend/model/classification/AppealType.scala
@@ -21,7 +21,7 @@ import uk.gov.hmrc.bindingtariffadminfrontend.util.JsonUtil
 
 object AppealType extends Enumeration {
   type AppealType = Value
-  val REVIEW, APPEAL_TIER_1, APPEAL_TIER_2, COURT_OF_APPEALS, SUPREME_COURT = Value
+  val ADR, REVIEW, APPEAL_TIER_1, APPEAL_TIER_2, COURT_OF_APPEALS, SUPREME_COURT = Value
 
   implicit val format: Format[AppealType.Value] = JsonUtil.format(AppealType)
 }


### PR DESCRIPTION
I think this is the cause of the PagerDuty alerts triggered today ([see kibana](https://kibana.tools.staging.tax.service.gov.uk/app/kibana#/dashboard/digital-tariffs-all?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(description:'',filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:match_all_logstash_ingested_logs_kibana_index_pattern,key:exception,negate:!f,params:(query:'uk.gov.hmrc.http.JsValidationException:%20GET%20of%20!'https:%2F%2Fbinding-tariff-classification.protected.mdtp:443%2Fcases%3Fpage%3D1%26page_size%3D10!'%20returned%20invalid%20json.%20Attempting%20to%20convert%20to%20uk.gov.hmrc.bindingtariffadminfrontend.model.Paged%20gave%20errors:%20List((,List(JsonValidationError(List(JsResultException(errors:List((%2Fdecision%2Fappeal(0)%2Ftype,List(JsonValidationError(List(error.expected.validenumvalue),WrappedArray())))))),WrappedArray()))))%0A%09at%20uk.gov.hmrc.http.HttpReadsLegacyJson.$anonfun$readJson$1(HttpReadsLegacyInstances.scala:66)%0A%09at%20play.api.libs.json.JsError.fold(JsResult.scala:64)%0A%09at%20uk.gov.hmrc.http.HttpReadsLegacyJson.uk$gov$hmrc$http$HttpReadsLegacyJson$$readJson(HttpReadsLegacyInstances.scala:67)%0A%09at%20uk.gov.hmrc.http.HttpReadsLegacyJson$$anon$3.read(HttpReadsLegacyInstances.scala:50)%0A%09at%20uk.gov.hmrc.http.HttpGet.$anonfun$GET$3(HttpGet.scala:48)%0A%09at%20scala.util.Success.$anonfun$map$1(Try.scala:255)%0A%09at%20scala.util.Success.map(Try.scala:213)%0A%09at%20scala.concurrent.Future.$anonfun$map$1(Future.scala:292)%0A%09at%20scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:33)%0A%09at%20scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:33)%0A%09at%20scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)%0A%09at%20java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)%0A%09at%20java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)%0A%09at%20java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)%0A%09at%20java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)%0A%09at%20java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)%0A',type:phrase),type:phrase,value:'uk.gov.hmrc.http.JsValidationException:%20GET%20of%20!'https:%2F%2Fbinding-tariff-classification.protected.mdtp:443%2Fcases%3Fpage%3D1%26page_size%3D10!'%20returned%20invalid%20json.%20Attempting%20to%20convert%20to%20uk.gov.hmrc.bindingtariffadminfrontend.model.Paged%20gave%20errors:%20List((,List(JsonValidationError(List(JsResultException(errors:List((%2Fdecision%2Fappeal(0)%2Ftype,List(JsonValidationError(List(error.expected.validenumvalue),WrappedArray())))))),WrappedArray()))))%0A%09at%20uk.gov.hmrc.http.HttpReadsLegacyJson.$anonfun$readJson$1(HttpReadsLegacyInstances.scala:66)%0A%09at%20play.api.libs.json.JsError.fold(JsResult.scala:64)%0A%09at%20uk.gov.hmrc.http.HttpReadsLegacyJson.uk$gov$hmrc$http$HttpReadsLegacyJson$$readJson(HttpReadsLegacyInstances.scala:67)%0A%09at%20uk.gov.hmrc.http.HttpReadsLegacyJson$$anon$3.read(HttpReadsLegacyInstances.scala:50)%0A%09at%20uk.gov.hmrc.http.HttpGet.$anonfun$GET$3(HttpGet.scala:48)%0A%09at%20scala.util.Success.$anonfun$map$1(Try.scala:255)%0A%09at%20scala.util.Success.map(Try.scala:213)%0A%09at%20scala.concurrent.Future.$anonfun$map$1(Future.scala:292)%0A%09at%20scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:33)%0A%09at%20scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:33)%0A%09at%20scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)%0A%09at%20java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)%0A%09at%20java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)%0A%09at%20java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)%0A%09at%20java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)%0A%09at%20java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)%0A'),query:(match:(exception:(query:'uk.gov.hmrc.http.JsValidationException:%20GET%20of%20!'https:%2F%2Fbinding-tariff-classification.protected.mdtp:443%2Fcases%3Fpage%3D1%26page_size%3D10!'%20returned%20invalid%20json.%20Attempting%20to%20convert%20to%20uk.gov.hmrc.bindingtariffadminfrontend.model.Paged%20gave%20errors:%20List((,List(JsonValidationError(List(JsResultException(errors:List((%2Fdecision%2Fappeal(0)%2Ftype,List(JsonValidationError(List(error.expected.validenumvalue),WrappedArray())))))),WrappedArray()))))%0A%09at%20uk.gov.hmrc.http.HttpReadsLegacyJson.$anonfun$readJson$1(HttpReadsLegacyInstances.scala:66)%0A%09at%20play.api.libs.json.JsError.fold(JsResult.scala:64)%0A%09at%20uk.gov.hmrc.http.HttpReadsLegacyJson.uk$gov$hmrc$http$HttpReadsLegacyJson$$readJson(HttpReadsLegacyInstances.scala:67)%0A%09at%20uk.gov.hmrc.http.HttpReadsLegacyJson$$anon$3.read(HttpReadsLegacyInstances.scala:50)%0A%09at%20uk.gov.hmrc.http.HttpGet.$anonfun$GET$3(HttpGet.scala:48)%0A%09at%20scala.util.Success.$anonfun$map$1(Try.scala:255)%0A%09at%20scala.util.Success.map(Try.scala:213)%0A%09at%20scala.concurrent.Future.$anonfun$map$1(Future.scala:292)%0A%09at%20scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:33)%0A%09at%20scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:33)%0A%09at%20scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)%0A%09at%20java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)%0A%09at%20java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)%0A%09at%20java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)%0A%09at%20java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)%0A%09at%20java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)%0A',type:phrase))))),fullScreenMode:!f,options:(),panels:!((gridData:(h:20,i:'1',w:24,x:0,y:0),id:digital-tariffs-all-http-requests,panelIndex:'1',type:visualization,version:'6.8.0'),(embeddableConfig:(columns:!(host,request),sort:!('@timestamp',desc)),gridData:(h:20,i:'2',w:24,x:0,y:20),id:digital-tariffs-all-http-requests,panelIndex:'2',type:search,version:'6.8.0'),(gridData:(h:20,i:'3',w:24,x:24,y:0),id:digital-tariffs-all-app-exceptions,panelIndex:'3',type:visualization,version:'6.8.0'),(embeddableConfig:(columns:!(app,host,exception),sort:!('@timestamp',desc)),gridData:(h:20,i:'4',w:24,x:24,y:20),id:digital-tariffs-all-app-exceptions,panelIndex:'4',type:search,version:'6.8.0'),(gridData:(h:10,i:'5',w:24,x:0,y:40),id:digital-tariffs-all-container-notifications,panelIndex:'5',type:visualization,version:'6.8.0'),(embeddableConfig:(columns:!('@fields.message','@fields.microservice','@fields.version'),sort:!('@timestamp',desc)),gridData:(h:10,i:'6',w:24,x:24,y:40),id:digital-tariffs-all-container-notifications,panelIndex:'6',type:search,version:'6.8.0'),(gridData:(h:10,i:'7',w:24,x:0,y:50),id:digital-tariffs-all-container-kill,panelIndex:'7',type:visualization,version:'6.8.0'),(embeddableConfig:(columns:!(service,version,host),sort:!('@timestamp',desc)),gridData:(h:10,i:'8',w:24,x:24,y:50),id:digital-tariffs-all-container-kill,panelIndex:'8',type:search,version:'6.8.0')),query:(language:lucene,query:''),timeRestore:!f,title:digital-tariffs-all,viewMode:view)))

Exception:

> uk.gov.hmrc.http.JsValidationException: GET of 'https://binding-tariff-classification.protected.mdtp:443/cases?page=1&page_size=10' returned invalid json. Attempting to convert to uk.gov.hmrc.bindingtariffadminfrontend.model.Paged gave errors: List((,List(JsonValidationError(List(JsResultException(errors:List((/decision/appeal(0)/type,List(JsonValidationError(List(error.expected.validenumvalue),WrappedArray())))))),WrappedArray()))))