### PR TITLE
DIT 2429 - Publish attachments immediately

### DIFF
--- a/app/uk/gov/hmrc/bindingtariffadminfrontend/controllers/MonitorController.scala
+++ b/app/uk/gov/hmrc/bindingtariffadminfrontend/controllers/MonitorController.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.bindingtariffadminfrontend.controllers
 
-import javax.inject.{Inject, Singleton}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc._
 import uk.gov.hmrc.bindingtariffadminfrontend.config.AppConfig
@@ -24,6 +23,7 @@ import uk.gov.hmrc.bindingtariffadminfrontend.service.AdminMonitorService
 import uk.gov.hmrc.bindingtariffadminfrontend.views.html.monitor
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext.Implicits.global
 
 @Singleton
@@ -38,10 +38,8 @@ class MonitorController @Inject() (
 
   def get: Action[AnyContent] = authenticatedAction.async { implicit request =>
     for {
-      cases            <- monitorService.countCases
-      publishedFiles   <- monitorService.countPublishedFiles
-      unpublishedFiles <- monitorService.countUnpublishedFiles
-    } yield Ok(monitor(cases, publishedFiles, unpublishedFiles))
+      monitorStatistics <- monitorService.getStatistics
+    } yield Ok(monitor(monitorStatistics))
   }
 
 }

--- a/app/uk/gov/hmrc/bindingtariffadminfrontend/model/MonitorStatistics.scala
+++ b/app/uk/gov/hmrc/bindingtariffadminfrontend/model/MonitorStatistics.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.bindingtariffadminfrontend.model
+
+import uk.gov.hmrc.bindingtariffadminfrontend.model.classification.ApplicationType
+import uk.gov.hmrc.bindingtariffadminfrontend.model.classification.ApplicationType.ApplicationType
+
+case class MonitorStatistics(
+  submittedCases: Map[ApplicationType, Int],
+  migratedCases: Map[ApplicationType, Int],
+  publishedFileCount: Int,
+  unpublishedFileCount: Int,
+  migratedAttachmentCount: Int
+) {
+  val allCases: Map[ApplicationType, Int] = ApplicationType.values
+    .map(applicationType =>
+      applicationType -> (submittedCases.getOrElse(applicationType, 0) + migratedCases.getOrElse(applicationType, 0))
+    )
+    .toMap
+
+  val totalCaseCount: Int = allCases.values.sum
+
+  val totalFileCount: Int = publishedFileCount + unpublishedFileCount
+}

--- a/app/uk/gov/hmrc/bindingtariffadminfrontend/model/Upload.scala
+++ b/app/uk/gov/hmrc/bindingtariffadminfrontend/model/Upload.scala
@@ -29,21 +29,27 @@ sealed case class AttachmentUpload(
   override val mimeType: String,
   override val id: String,
   override val batchId: String
-) extends Upload
+) extends Upload {
+  override val publishable: Boolean = true
+}
 
 sealed case class MigrationDataUpload(
   override val fileName: String,
   override val mimeType: String,
   override val id: String,
   override val batchId: String
-) extends Upload
+) extends Upload {
+  override val publishable: Boolean = false
+}
 
 sealed case class HistoricDataUpload(
   override val fileName: String,
   override val mimeType: String,
   override val id: String,
   override val batchId: String
-) extends Upload
+) extends Upload {
+  override val publishable: Boolean = false
+}
 
 object Upload {
   implicit val attachmentFormat: Format[AttachmentUpload]   = Json.format[AttachmentUpload]

--- a/app/uk/gov/hmrc/bindingtariffadminfrontend/model/filestore/UploadRequest.scala
+++ b/app/uk/gov/hmrc/bindingtariffadminfrontend/model/filestore/UploadRequest.scala
@@ -22,14 +22,16 @@ abstract class UploadRequest {
   def id: String
   def fileName: String
   def mimeType: String
+  def publishable: Boolean
 }
 
 object UploadRequest {
   implicit val writes: Writes[UploadRequest] = Writes(upload =>
     Json.obj(
-      "id"       -> upload.id,
-      "fileName" -> upload.fileName,
-      "mimeType" -> upload.mimeType
+      "id"          -> upload.id,
+      "fileName"    -> upload.fileName,
+      "mimeType"    -> upload.mimeType,
+      "publishable" -> upload.publishable
     )
   )
 }

--- a/app/uk/gov/hmrc/bindingtariffadminfrontend/repository/UploadRepository.scala
+++ b/app/uk/gov/hmrc/bindingtariffadminfrontend/repository/UploadRepository.scala
@@ -48,6 +48,8 @@ trait UploadRepository {
   def deleteAll(): Future[Unit]
 
   def deleteById(id: String): Future[Unit]
+
+  def countType[T <: Upload: ClassTag]: Future[Int]
 }
 
 @Singleton
@@ -107,6 +109,10 @@ class UploadMongoRepository @Inject() (config: AppConfig, mongoDbProvider: Mongo
     collection
       .findAndRemove(selector = byId(id))
       .map(_ => ())
+
+  override def countType[T <: Upload: ClassTag]: Future[Int] =
+    collection
+      .count(selector = Some(byType[T]))
 
   private def byId(id: String): JsObject =
     Json.obj("id" -> id)

--- a/app/uk/gov/hmrc/bindingtariffadminfrontend/views/index.scala.html
+++ b/app/uk/gov/hmrc/bindingtariffadminfrontend/views/index.scala.html
@@ -29,11 +29,11 @@
 
  <ul class="list list-bullet">
   <li>
-   <a id="index-migration_state" href="@routes.DataMigrationStateController.get()">View the current state of migrations</a>
+   <a id="index-dashboard" href="@routes.MonitorController.get()">View the Digital Tariffs Dashboard</a>
   </li>
 
   <li>
-   <a id="index-dashboard" href="@routes.MonitorController.get()">View the Digital Tariffs Dashboard</a>
+   <a id="index-migration_state" href="@routes.DataMigrationStateController.get()">View the current state of migrations</a>
   </li>
 
   <li>

--- a/app/uk/gov/hmrc/bindingtariffadminfrontend/views/monitor.scala.html
+++ b/app/uk/gov/hmrc/bindingtariffadminfrontend/views/monitor.scala.html
@@ -16,11 +16,12 @@
 
 @import uk.gov.hmrc.bindingtariffadminfrontend.config.AppConfig
 @import uk.gov.hmrc.bindingtariffadminfrontend.controllers.routes
-@import uk.gov.hmrc.bindingtariffadminfrontend.model.AuthenticatedRequest
+@import uk.gov.hmrc.bindingtariffadminfrontend.model.{AuthenticatedRequest, MonitorStatistics}
+@import uk.gov.hmrc.bindingtariffadminfrontend.model.classification.ApplicationType
 @import uk.gov.hmrc.bindingtariffadminfrontend.views.html.components.{error_summary, input_file, submit_button}
 @import uk.gov.hmrc.bindingtariffadminfrontend.views.html.main_template
 @import uk.gov.hmrc.play.views.html.helpers
-@(cases: Int, publishedFiles: Int, unpublishedFiles: Int)(implicit request: AuthenticatedRequest[_], messages: Messages, appConfig: AppConfig)
+@(monitorStatistics: MonitorStatistics)(implicit request: AuthenticatedRequest[_], messages: Messages, appConfig: AppConfig)
 
 @main_template(title = "Binding Tariff Admin", bodyClasses = None) {
 
@@ -28,23 +29,68 @@
 
  <h1 id="monitor-heading" class="heading-xlarge">Digital Tariffs Monitor</h1>
 
- <h2 class="heading-medium">There is currently:</h2>
+ <h2 class="heading-medium">There are currently:</h2>
 
  <div class="grid-row">
 
   <div class="column-one-third data">
-   <span class="data-item bold-xxlarge">@cases</span>
-   <span class="data-item bold-xsmall">Cases</span>
+   <div class="data-item">
+    <span class="bold-xxlarge">@monitorStatistics.totalCaseCount</span>
+    <span class="bold-large">Cases</span>
+   </div>
   </div>
 
   <div class="column-one-third data">
-   <span class="data-item bold-xxlarge">@publishedFiles</span>
-   <span class="data-item bold-xsmall">Published Files</span>
+   <div class="data-item">
+    <span class="bold-large">@monitorStatistics.migratedCases.getOrElse(ApplicationType.BTI, 0)</span>
+    <span class="bold-xsmall">Migrated BTIs</span>
+   </div>
+   <div class="data-item">
+    <span class="bold-large">@monitorStatistics.migratedCases.getOrElse(ApplicationType.LIABILITY_ORDER, 0)</span>
+    <span class="bold-xsmall">Migrated Liabilities</span>
+   </div>
   </div>
 
   <div class="column-one-third data">
-   <span class="data-item bold-xxlarge">@unpublishedFiles</span>
-   <span class="data-item bold-xsmall">Unpublished Files</span>
+   <div class="data-item">
+    <span class="bold-large">@monitorStatistics.submittedCases.getOrElse(ApplicationType.BTI, 0)</span>
+    <span class="bold-xsmall">Submitted ATARs</span>
+   </div>
+   <div class="data-item">
+    <span class="bold-large">@monitorStatistics.submittedCases.getOrElse(ApplicationType.LIABILITY_ORDER, 0)</span>
+    <span class="bold-xsmall">Submitted Liabilities</span>
+   </div>
+  </div>
+
+ </div>
+
+ <hr/>
+
+ <div class="grid-row">
+
+  <div class="column-one-third data">
+   <div class="data-item">
+    <span class="bold-xxlarge">@monitorStatistics.totalFileCount</span>
+    <span class="bold-large">Files</span>
+   </div>
+  </div>
+
+  <div class="column-one-third data">
+   <div class="data-item">
+    <span class="bold-large">@monitorStatistics.publishedFileCount</span>
+    <span class="bold-xsmall">Published Files</span>
+   </div>
+   <div class="data-item">
+    <span class="bold-large">@monitorStatistics.unpublishedFileCount</span>
+    <span class="bold-xsmall">Unpublished Files</span>
+   </div>
+  </div>
+
+  <div class="column-one-third data">
+   <div class="data-item">
+    <span class="bold-large">@monitorStatistics.migratedAttachmentCount</span>
+    <span class="bold-xsmall">Migrated attachments</span>
+   </div>
   </div>
 
  </div>

--- a/test/unit/uk/gov/hmrc/bindingtariffadminfrontend/controllers/MonitorControllerControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffadminfrontend/controllers/MonitorControllerControllerSpec.scala
@@ -16,18 +16,15 @@
 
 package uk.gov.hmrc.bindingtariffadminfrontend.controllers
 
-import akka.stream.Materializer
 import org.mockito.ArgumentMatchers._
 import org.mockito.BDDMockito.given
 import org.mockito.Mockito
-import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterEach
 import play.api.http.Status.OK
-import play.api.i18n.{DefaultLangs, DefaultMessagesApi}
 import play.api.mvc.Result
 import play.api.test.FakeRequest
-import play.api.{Configuration, Environment}
-import uk.gov.hmrc.bindingtariffadminfrontend.config.AppConfig
+import uk.gov.hmrc.bindingtariffadminfrontend.model.MonitorStatistics
+import uk.gov.hmrc.bindingtariffadminfrontend.model.classification.ApplicationType
 import uk.gov.hmrc.bindingtariffadminfrontend.service.AdminMonitorService
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -50,13 +47,20 @@ class MonitorControllerControllerSpec extends ControllerSpec with BeforeAndAfter
     Mockito.reset(mockAppConfig)
   }
 
+  private val statistics = MonitorStatistics(
+    submittedCases          = Map(ApplicationType.BTI -> 2, ApplicationType.LIABILITY_ORDER -> 3),
+    migratedCases           = Map(ApplicationType.BTI -> 12, ApplicationType.LIABILITY_ORDER -> 13),
+    publishedFileCount      = 105,
+    unpublishedFileCount    = 95,
+    migratedAttachmentCount = 66
+  )
+
   "GET /" should {
     "return 200" in {
-      given(service.countCases(any[HeaderCarrier])).willReturn(Future.successful(1))
-      given(service.countUnpublishedFiles(any[HeaderCarrier])).willReturn(Future.successful(1))
-      given(service.countPublishedFiles(any[HeaderCarrier])).willReturn(Future.successful(1))
+      given(service.getStatistics(any[HeaderCarrier])).willReturn(Future.successful(statistics))
 
       val result: Result = await(controller.get()(FakeRequest()))
+
       status(result) shouldBe OK
       bodyOf(result) should include("monitor-heading")
     }

--- a/test/unit/uk/gov/hmrc/bindingtariffadminfrontend/model/MonitorStatisticsTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffadminfrontend/model/MonitorStatisticsTest.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.bindingtariffadminfrontend.model
+
+import uk.gov.hmrc.bindingtariffadminfrontend.model.classification.ApplicationType
+import uk.gov.hmrc.bindingtariffadminfrontend.util.UnitSpec
+
+class MonitorStatisticsTest extends UnitSpec {
+
+  private val statistics = MonitorStatistics(
+    submittedCases          = Map(ApplicationType.BTI -> 2, ApplicationType.LIABILITY_ORDER -> 3),
+    migratedCases           = Map(ApplicationType.BTI -> 12, ApplicationType.LIABILITY_ORDER -> 13),
+    publishedFileCount      = 105,
+    unpublishedFileCount    = 95,
+    migratedAttachmentCount = 66
+  )
+
+  "allCases" should {
+    "return the correct map" in {
+      statistics.allCases shouldBe Map(ApplicationType.BTI -> 14, ApplicationType.LIABILITY_ORDER -> 16)
+    }
+  }
+
+  "totalCaseCount" should {
+    "return the correct number" in {
+      statistics.totalCaseCount shouldBe 30
+    }
+  }
+
+  "totalFileCount" should {
+    "return the correct number" in {
+      statistics.totalFileCount shouldBe 200
+    }
+  }
+}

--- a/test/unit/uk/gov/hmrc/bindingtariffadminfrontend/model/filestore/UploadRequestSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffadminfrontend/model/filestore/UploadRequestSpec.scala
@@ -17,27 +17,61 @@
 package uk.gov.hmrc.bindingtariffadminfrontend.model.filestore
 
 import java.util.UUID
-
 import play.api.libs.json.Json
-import uk.gov.hmrc.bindingtariffadminfrontend.model.AttachmentUpload
+import uk.gov.hmrc.bindingtariffadminfrontend.model.{AttachmentUpload, HistoricDataUpload, MigrationDataUpload}
 import uk.gov.hmrc.bindingtariffadminfrontend.util.UnitSpec
 
 class UploadRequestSpec extends UnitSpec {
-  private val uploadRequest: UploadRequest = AttachmentUpload(
+  private val attachmentUpload: UploadRequest = AttachmentUpload(
     fileName = "1234-01.jpg",
     mimeType = "image/jpg",
     id       = "id",
     batchId  = UUID.randomUUID().toString
   )
 
+  private val migrationDataUpload: UploadRequest = MigrationDataUpload(
+    fileName = "tblImages.csv",
+    mimeType = "text/csv",
+    id       = "id",
+    batchId  = UUID.randomUUID().toString
+  )
+
+  private val historicDataUpload: UploadRequest = HistoricDataUpload(
+    fileName = "ALLAPPLDATA-2004.txt",
+    mimeType = "text/plain",
+    id       = "id",
+    batchId  = UUID.randomUUID().toString
+  )
+
   "writes" should {
-    "return valid json" in {
-      Json.toJson(uploadRequest)(UploadRequest.writes) shouldBe
+    "return valid json for attachments" in {
+      Json.toJson(attachmentUpload)(UploadRequest.writes) shouldBe
         Json.parse("""{
                |        "id": "id",
                |        "fileName": "1234-01.jpg",
-               |        "mimeType": "image/jpg"
+               |        "mimeType": "image/jpg",
+               |        "publishable": true
                |      }""".stripMargin)
+    }
+
+    "return valid json for migration files" in {
+      Json.toJson(migrationDataUpload)(UploadRequest.writes) shouldBe
+        Json.parse("""{
+                |       "id": "id",
+                |       "fileName": "tblImages.csv",
+                |       "mimeType": "text/csv",
+                |       "publishable": false
+                |     }""".stripMargin)
+    }
+
+    "return valid json for historic data files" in {
+      Json.toJson(historicDataUpload)(UploadRequest.writes) shouldBe
+        Json.parse("""{
+                 |      "id": "id",
+                 |      "fileName": "ALLAPPLDATA-2004.txt",
+                 |      "mimeType": "text/plain",
+                 |      "publishable": false
+                 |    }""".stripMargin)
     }
   }
 }


### PR DESCRIPTION
By marking uploaded attachments as publishable then the FileStore will immediately publish them, and the existing case migration logic will skip already-published attachments.

In the future we will need to cleanup attachments that are no longer linked to any cases.